### PR TITLE
feat: geolocations

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,15 @@ You will see the following data structure:
 }
 ```
 
+## Dev
+
+To use docker locally run this:
+```shell
+# git clone git@github.com:Umkus/ip-index.git
+# cd ip-index
+docker compose -f docker-compose.yml -f docker-compose.override.yml up -d
+```
+
 ## Why this exists
 
 Most existing solutions to detect VPNs/Proxies provide HTTP APIs or binary databases on a subscription model. Downsides of the existing projects might be at least one of the following:

--- a/README.md
+++ b/README.md
@@ -31,6 +31,28 @@ Now open this url in your browser: [http://localhost/?ip=8.8.8.8](http://localho
 You will see the following data structure:
 
 ```json
+[
+  {
+    "start": "134744064",
+    "end": "134744319",
+    "subnet": "8.8.8.0/24",
+    "asn": 15169,
+    "hosting": true,
+    "country": "US",
+    "handle": "GOOGLE",
+    "description": "Google",
+    "subnetsNum": 956
+  }
+]
+```
+
+### Geolocations
+
+Open this url in your browser: [http://localhost/?ip=8.8.8.8&withGeolocations](http://localhost/?ip=8.8.8.8&withGeolocations)
+
+You will see the following data structure:
+
+```json
 {
   "asns": [
     {

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Alternatively for a more advanced usage with pre-configured nginx throttling and
 ```shell
 # git clone git@github.com:Umkus/ip-index.git
 # cd ip-index
+# npm i
 docker compose -f docker-compose.yml up -d
 ```
 
@@ -85,6 +86,7 @@ To use docker locally run this:
 ```shell
 # git clone git@github.com:Umkus/ip-index.git
 # cd ip-index
+# npm i
 docker compose -f docker-compose.yml -f docker-compose.override.yml up -d
 ```
 

--- a/README.md
+++ b/README.md
@@ -31,20 +31,30 @@ Now open this url in your browser: [http://localhost/?ip=8.8.8.8](http://localho
 You will see the following data structure:
 
 ```json
-[
-  {
-    "start": "134744064",
-    "end": "134744319",
-    "subnet": "8.8.8.0/24",
-    "asn": 15169,
-    "hosting": true,
-    "country": "US",
-    "handle": "GOOGLE",
-    "description": "Google",
-    "subnetsNum": 956
-  }
-]
-
+{
+  "asns": [
+    {
+      "start": "134744064",
+      "end": "134744319",
+      "subnet": "8.8.8.0/24",
+      "asn": 15169,
+      "hosting": true,
+      "country": "US",
+      "handle": "GOOGLE",
+      "description": "Google",
+      "subnetsNum": 956
+    }
+  ],
+  "geolocations": [
+    {
+      "start": "134217728",
+      "end": "142606335",
+      "latitude": "32.50931",
+      "longitue": "-92.1193",
+      "accuracy": "4"
+    }
+  ]
+}
 ```
 
 ## Why this exists

--- a/nginx.conf
+++ b/nginx.conf
@@ -73,9 +73,9 @@ http
     }
 
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-    proxy_connect_timeout       5s;
-    proxy_send_timeout          5s;
-    proxy_read_timeout          5s;
+    proxy_connect_timeout       15s;
+    proxy_send_timeout          15s;
+    proxy_read_timeout          15s;
     proxy_pass_request_headers  on;
     underscores_in_headers      on;
 

--- a/src/example.js
+++ b/src/example.js
@@ -5,8 +5,16 @@ const ip = '8.8.8.8'
 
 console.time('query time')
 const ipInfo = getIpInfo(ip)
-const asnInfo = getAsnInfo(ipInfo.asns[0]?.asn)
+const asnInfo = getAsnInfo(ipInfo.asn)
 console.timeEnd('query time')
 
 console.log('IP Info', ipInfo)
 console.log('ASN Info', asnInfo)
+
+console.time('query time with geolocations')
+const ipInfoWithGeolocations = getIpInfo(ip, true)
+const asnInfoWithGeolocations = getAsnInfo(ipInfoWithGeolocations.asns[0]?.asn)
+console.timeEnd('query time with geolocations')
+
+console.log('IP Info with Geolocations', ipInfoWithGeolocations)
+console.log('ASN Info with Geolocations', asnInfoWithGeolocations)

--- a/src/example.js
+++ b/src/example.js
@@ -5,7 +5,7 @@ const ip = '8.8.8.8'
 
 console.time('query time')
 const ipInfo = getIpInfo(ip)
-const asnInfo = getAsnInfo(ipInfo[0]?.asn)
+const asnInfo = getAsnInfo(ipInfo.asns[0]?.asn)
 console.timeEnd('query time')
 
 console.log('IP Info', ipInfo)

--- a/src/index.js
+++ b/src/index.js
@@ -145,7 +145,17 @@ function getAsns(ip) {
 function getGeolocation(ip) {
   const ipInt = ipToInt(ip)
 
-  return geolocationRangesIndexed.filter(({ start, end }) => ipInt >= start && ipInt <= end)
+  const validRanges = []
+  for (const range of geolocationRangesIndexed) {
+    const { start, end } = range
+    if (ipInt < start) break // we can stop searching because array is sorted by start
+
+
+    if (ipInt >= start && ipInt <= end) {
+      validRanges.push(range)
+    }
+  }
+  return validRanges
 }
 
 

--- a/src/index.js
+++ b/src/index.js
@@ -192,11 +192,18 @@ function getGeolocations(ip) {
 }
 
 
-export function getIpInfo(ip) {
+export function getIpInfo(ip, withGeolocations = false) {
+  let res
+
   console.time("fetch")
   const asns = getAsns(ip)
-  const geolocations = getGeolocations(ip)
+  if (withGeolocations) {
+    const geolocations = getGeolocations(ip)
+    res = { asns, geolocations }
+  } else {
+    res = asns
+  }
   console.timeEnd("fetch")
 
-  return { asns, geolocations }
+  return res
 }

--- a/src/index.js
+++ b/src/index.js
@@ -142,7 +142,7 @@ function getAsns(ip) {
     .map((match) => ({ ...match, ...asns[match.asn] }))
 }
 
-function getGeolocation(ip) {
+function getGeolocations(ip) {
   const ipInt = ipToInt(ip)
 
   const validRanges = []
@@ -184,8 +184,8 @@ function getGeolocation(ip) {
 export function getIpInfo(ip) {
   console.time("fetch")
   const asns = getAsns(ip)
-  const geolocation = getGeolocation(ip)
+  const geolocations = getGeolocations(ip)
   console.timeEnd("fetch")
 
-  return { asns, geolocation }
+  return { asns, geolocations }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -28,7 +28,7 @@ readFileSync(`${__dirname}/../data/asns_dcs.csv`).toString().split(/\s+/)
 
 const asnCidrs = {}
 const asnRangesIndexed = {}
-const geolocationRangesIndexed = []
+const geolocationRanges = []
 
 function getPosition(subnet, start) {
   const part = subnet.split(/[:\.]/)[start]
@@ -77,7 +77,7 @@ readFileSync(`${__dirname}/../data/asns_cidrs_2.csv`).toString()
     asnRangesIndexed[rangeIndex][rangeIndex2].push(range)
   })
 
-readFileSync(`${__dirname}/../data/geolocation.csv`).toString()
+readFileSync(`${__dirname}/../data/geolocations.csv`).toString()
   .split(/\s+/)
   .filter(Boolean)
   .forEach((item) => {
@@ -94,7 +94,7 @@ readFileSync(`${__dirname}/../data/geolocation.csv`).toString()
       accuracy
     }
 
-    geolocationRangesIndexed.push(range) 
+    geolocationRanges.push(range) 
   })
 
 function ipToInt(ip) {
@@ -165,7 +165,7 @@ function getGeolocations(ip) {
       binarySearch(arr, val, midIdx + 1, endIdx)
     }
   }
-  binarySearch(geolocationRangesIndexed, ipInt)
+  binarySearch(geolocationRanges, ipInt)
 
   // Sort by accuracy DESC, then by range length DESC
   return validRanges.sort((a, b) => {

--- a/src/index.js
+++ b/src/index.js
@@ -155,7 +155,29 @@ function getGeolocation(ip) {
       validRanges.push(range)
     }
   }
-  return validRanges
+
+  // Sort by accuracy DESC, then by range length DESC
+  return validRanges.sort((a, b) => {
+    const aNum = a.accuracy
+    const bNum = b.accuracy
+  
+    if (aNum < bNum) {
+      return -1
+    } else if (aNum > bNum) {
+      return 1
+    } else {
+      const a2Num = a.end - a.start
+      const b2Num = b.end - b.start
+
+      if (a2Num < b2Num) {
+        return -1
+      } else if (a2Num > b2Num) {
+        return 1
+      } else {
+        return 0
+      }
+    }
+  })
 }
 
 

--- a/src/index.js
+++ b/src/index.js
@@ -99,7 +99,7 @@ export function getAsnInfo(asn) {
   return { ...asns[asn], subnets: asnCidrs[asn] || [] }
 }
 
-export function getIpInfo(ip) {
+function getAsns(ip) {
   const ipPosition1 = getPosition(ip, 0)
   let ipPosition2 = getPosition(ip, 1)
   const ipInt = ipToInt(ip)
@@ -122,4 +122,11 @@ export function getIpInfo(ip) {
 
   return filtered
     .map((match) => ({ ...match, ...asns[match.asn] }))
+}
+
+
+export function getIpInfo(ip) {
+  return {
+    asns: getAsns(ip)
+  }
 }

--- a/src/post-install-2.js
+++ b/src/post-install-2.js
@@ -55,6 +55,7 @@ const geolocationV6Data = readFileSync(`${__dirname}/../data/geolocationDatabase
 console.timeEnd('parsed')
 
 console.time('indexed')
+// Sort by range start DESC
 const compareForIndex = (a, b) => {
     const aNum = a.start
     const bNum = b.start

--- a/src/post-install-2.js
+++ b/src/post-install-2.js
@@ -59,13 +59,7 @@ const compareForIndex = (a, b) => {
     const aNum = a.start
     const bNum = b.start
 
-    if (aNum < bNum) {
-        return -1
-    } else if (aNum > bNum) {
-        return 1
-    } else {
-        return 0
-    }
+    return aNum.compareTo(bNum)
 }
 function getAsnIndex(subnet, asn, ipFamily, country) {
     let ip
@@ -127,9 +121,6 @@ const geolocationIndex = [...geolocationV4Data, ...geolocationV6Data]
             accuracy,
         }
     }).sort(compareForIndex)
-
-console.log(geolocationIndex.slice(0, 10))
-
 console.timeEnd('indexed')
 
 writeFileSync(`${__dirname}/../data/asns_cidrs_2.csv`, asnsIndex.map(({ asn, subnet, start, end, country }) => `${asn},${subnet},${start},${end},${country}`).join('\n'));

--- a/src/post-install-2.js
+++ b/src/post-install-2.js
@@ -44,11 +44,11 @@ console.timeEnd('downloaded')
 
 console.time('parsed')
 const asnsData = JSON.parse(readFileSync(`${__dirname}/../data/fullASN.json`).toString())
-const geolocationV4Data = readFileSync(`${__dirname}/../data/geolocationDatabaseIPv4.csv`)
+const geolocationsV4Data = readFileSync(`${__dirname}/../data/geolocationDatabaseIPv4.csv`)
     .toString()
     .split('\n')
     .slice(1) // skip header
-const geolocationV6Data = readFileSync(`${__dirname}/../data/geolocationDatabaseIPv6.csv`)
+const geolocationsV6Data = readFileSync(`${__dirname}/../data/geolocationDatabaseIPv6.csv`)
     .toString()
     .split('\n')
     .slice(1) // skip header
@@ -96,7 +96,7 @@ const asnsIndex = Object.keys(asnsData).flatMap((asn) => {
     ]
 }).sort(compareForIndex)
 
-const geolocationIndex = [...geolocationV4Data, ...geolocationV6Data]
+const geolocationsIndex = [...geolocationsV4Data, ...geolocationsV6Data]
     .filter(Boolean)
     .map(row => {
         const [ipFamily,startIp,endIp,,,,,,,,latitude,longitude,accuracy] = row.split(',')
@@ -125,4 +125,4 @@ const geolocationIndex = [...geolocationV4Data, ...geolocationV6Data]
 console.timeEnd('indexed')
 
 writeFileSync(`${__dirname}/../data/asns_cidrs_2.csv`, asnsIndex.map(({ asn, subnet, start, end, country }) => `${asn},${subnet},${start},${end},${country}`).join('\n'));
-writeFileSync(`${__dirname}/../data/geolocation.csv`, geolocationIndex.map(({ start, end, latitude, longitude, accuracy }) => `${start},${end},${latitude},${longitude},${accuracy}`).join('\n'));
+writeFileSync(`${__dirname}/../data/geolocations.csv`, geolocationsIndex.map(({ start, end, latitude, longitude, accuracy }) => `${start},${end},${latitude},${longitude},${accuracy}`).join('\n'));

--- a/src/server.js
+++ b/src/server.js
@@ -5,12 +5,13 @@ import { getIpInfo } from './index.js';
 http.createServer(async (req, res) => {
   const { searchParams } = new url.URL(`http://localhost${req.url}`);
   const ip = searchParams.get('ip') || req.headers['x-forwarded-for'] || req.socket.remoteAddress;
+  const withGeolocations = searchParams.has('withGeolocations') || false
 
   res.writeHead(200, {
     'Content-Type': 'application/json',
   });
 
-  res.write(JSON.stringify(getIpInfo(ip), (key, value) => {
+  res.write(JSON.stringify(getIpInfo(ip, withGeolocations), (key, value) => {
     if (typeof value === "bigint") {
       return value.toString()
     }


### PR DESCRIPTION
Fetches found geolocations of client.
It is non-breaking change. To use it, pass `withGeolocations` - it will return new output to be non-breaking change:
```json
{
  "asns": [],
  "geolocations": []
}
```

I put it as draft because it is not efficient enough to do the lookup.
I did not have time to think about how to do it more efficiently - my main problem was BigInt and ranges that can overlap for some reason.
One approach could be to split overlapping ranges so that the search can be more efficient.

Anyway, maybe this PR can be a source of inspiration.